### PR TITLE
updated to exclude deploy task in build command for ORF4450.Robot19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ def ROBOT_MAIN_CLASS = "Team4450.Robot19.Main"
 
 // If you want the build task to automatically attempt to deploy to the robot, leave this as is.
 // If you are using VSCode to deploy, it is recommended to comment this line out and use the Deploy command in VSCode.
-build.finalizedBy 'deploy'
+// build.finalizedBy 'deploy'
 
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project EmbeddedTools.


### PR DESCRIPTION
This enables build task in gradle to do *only* build. This will allow developers to work offline even when they don't have test robot connected for testing.
This will force developers to use deploy separately than build.